### PR TITLE
Add team profile page

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 import logging
 
-from app.routers import fixtures, predictions, table, calibration, model_params, backtest as backtest_router, simulation as simulation_router
+from app.routers import fixtures, predictions, table, calibration, model_params, backtest as backtest_router, simulation as simulation_router, teams as teams_router
 from app.services import backtest as backtest_service
 import asyncio
 from app.services.dixon_coles import get_model, get_model_bayes
@@ -117,6 +117,7 @@ app.include_router(calibration.router, prefix="/api")
 app.include_router(model_params.router, prefix="/api")
 app.include_router(backtest_router.router, prefix="/api")
 app.include_router(simulation_router.router, prefix="/api")
+app.include_router(teams_router.router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -177,6 +177,51 @@ class SimulationResult(BaseModel):
     teams: list[TeamSimResult]
 
 
+# ---------------------------------------------------------------------------
+# Team profile
+# ---------------------------------------------------------------------------
+
+class TeamSeasonResult(BaseModel):
+    date: str
+    matchday: Optional[int]
+    home_team: str
+    away_team: str
+    home_goals: int
+    away_goals: int
+
+
+class TeamUpcomingFixture(BaseModel):
+    fixture_id: int
+    date: str
+    matchday: int
+    home_team: str
+    away_team: str
+    home_win_prob: float
+    draw_prob: float
+    away_win_prob: float
+    expected_home_goals: float
+    expected_away_goals: float
+
+
+class TeamProfileResponse(BaseModel):
+    team: str
+    alpha: float
+    delta: float
+    gamma: float
+    form: float
+    avg_alpha: float
+    avg_delta: float
+    avg_gamma: float
+    avg_form: float
+    alpha_bayes: Optional[float] = None
+    delta_bayes: Optional[float] = None
+    gamma_bayes: Optional[float] = None
+    form_bayes: Optional[float] = None
+    bayes_fitted: bool
+    season_results: list[TeamSeasonResult]
+    upcoming: list[TeamUpcomingFixture]
+
+
 class Prediction(BaseModel):
     fixture: Fixture
     score_matrix: ScoreMatrix

--- a/backend/app/routers/teams.py
+++ b/backend/app/routers/teams.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter, HTTPException
+from datetime import datetime, timezone
+import numpy as np
+
+from app.services.dixon_coles import get_model, get_model_bayes
+from app.services.football_data import get_current_and_upcoming_fixtures
+from app.models.schemas import TeamProfileResponse, TeamSeasonResult, TeamUpcomingFixture
+
+router = APIRouter(prefix="/teams", tags=["teams"])
+
+
+@router.get("/{team_name}", response_model=TeamProfileResponse)
+async def get_team_profile(team_name: str):
+    model = get_model()
+    if not model.fitted:
+        raise HTTPException(status_code=503, detail="Model not yet fitted.")
+
+    # Case-insensitive team lookup
+    resolved = next((t for t in model.teams if t.lower() == team_name.lower()), None)
+    if resolved is None:
+        raise HTTPException(status_code=404, detail=f"Team '{team_name}' not found in model.")
+    team_name = resolved
+
+    avg_alpha = float(np.mean(list(model.alphas.values())))
+    avg_delta = float(np.mean(list(model.deltas.values())))
+    avg_gamma = float(np.mean(list(model.gammas.values())))
+    avg_form  = float(np.mean(list(model.form.values()))) if model.form else 1.0
+
+    bayes = get_model_bayes()
+    alpha_bayes = delta_bayes = gamma_bayes = form_bayes = None
+    if bayes.fitted and team_name in bayes.alphas:
+        alpha_bayes = round(bayes.alphas[team_name], 4)
+        delta_bayes = round(bayes.deltas[team_name], 4)
+        gamma_bayes = round(bayes.gammas.get(team_name, avg_gamma), 4)
+        form_bayes  = round(bayes.form.get(team_name, avg_form), 4)
+
+    # Current season results from training data
+    current_year = str(datetime.now(timezone.utc).year)
+    season_results: list[TeamSeasonResult] = []
+    if model._h2h_df is not None:
+        df = model._h2h_df
+        mask = (
+            ((df["home_team"] == team_name) | (df["away_team"] == team_name)) &
+            df["date"].str.startswith(current_year)
+        )
+        for _, row in df[mask].sort_values("date", ascending=False).iterrows():
+            md = int(row["matchday"]) if "matchday" in df.columns and row.get("matchday") else None
+            season_results.append(TeamSeasonResult(
+                date=str(row["date"])[:10],
+                matchday=md,
+                home_team=str(row["home_team"]),
+                away_team=str(row["away_team"]),
+                home_goals=int(row["home_goals"]),
+                away_goals=int(row["away_goals"]),
+            ))
+
+    # Upcoming fixtures with predictions
+    upcoming: list[TeamUpcomingFixture] = []
+    for fixture in await get_current_and_upcoming_fixtures():
+        if fixture.status not in ("SCHEDULED", "TIMED"):
+            continue
+        ht, at = fixture.home_team.name, fixture.away_team.name
+        if ht != team_name and at != team_name:
+            continue
+        try:
+            pred = model.predict(ht, at, fixture_date=fixture.utc_date.isoformat())
+            upcoming.append(TeamUpcomingFixture(
+                fixture_id=fixture.id,
+                date=fixture.utc_date.isoformat(),
+                matchday=fixture.matchday,
+                home_team=ht,
+                away_team=at,
+                home_win_prob=pred["home_win"],
+                draw_prob=pred["draw"],
+                away_win_prob=pred["away_win"],
+                expected_home_goals=pred["expected_home_goals"],
+                expected_away_goals=pred["expected_away_goals"],
+            ))
+        except Exception:
+            pass
+
+    return TeamProfileResponse(
+        team=team_name,
+        alpha=round(model.alphas.get(team_name, avg_alpha), 4),
+        delta=round(model.deltas.get(team_name, avg_delta), 4),
+        gamma=round(model.gammas.get(team_name, avg_gamma), 4),
+        form=round(model.form.get(team_name, avg_form), 4),
+        avg_alpha=round(avg_alpha, 4),
+        avg_delta=round(avg_delta, 4),
+        avg_gamma=round(avg_gamma, 4),
+        avg_form=round(avg_form, 4),
+        alpha_bayes=alpha_bayes,
+        delta_bayes=delta_bayes,
+        gamma_bayes=gamma_bayes,
+        form_bayes=form_bayes,
+        bayes_fitted=bayes.fitted,
+        season_results=season_results,
+        upcoming=upcoming,
+    )

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import AccuracySummary from './components/AccuracySummary'
 import Tipp11Summary from './components/Tipp11Summary'
 import CalibrationView from './components/CalibrationView'
 import BacktestView from './components/BacktestView'
+import TeamProfile from './components/TeamProfile'
 import { blendScoreMatrix } from './utils/blendOdds'
 import { bestTipp11Tip } from './utils/tipp11'
 import './App.css'
@@ -140,6 +141,7 @@ export default function App() {
   const [bayesPredictions, setBayesPredictions] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [profileTeam, setProfileTeam] = useState(null)
 
   useEffect(() => {
     axios.get(`/api/predictions/upcoming?model_variant=${modelVariant}`)
@@ -229,6 +231,7 @@ export default function App() {
   return (
     <div className="app">
       <AppHeader />
+      {profileTeam && <TeamProfile teamName={profileTeam} onClose={() => setProfileTeam(null)} />}
 
       <div className={`app-body${showTable || showCalibration || showBacktest ? ' no-sidebar' : ''}`}>
         {visiblePredictions.length > 0 && !showTable && !showCalibration && !showBacktest && (
@@ -358,7 +361,7 @@ export default function App() {
           ) : showCalibration ? (
             <CalibrationView />
           ) : showTable ? (
-            <LeagueTable />
+            <LeagueTable onTeamClick={setProfileTeam} />
           ) : (
             <>
               {visiblePredictions.length === 0 && !loading && (
@@ -369,7 +372,7 @@ export default function App() {
               <div className="fixture-list">
                 {visiblePredictions.map(p => (
                   <div key={p.fixture.id} id={`fixture-${p.fixture.id}`}>
-                    <FixtureCard prediction={p} showTipp11={showTipp11} blendOdds={blendOdds} />
+                    <FixtureCard prediction={p} showTipp11={showTipp11} blendOdds={blendOdds} onTeamClick={setProfileTeam} />
                   </div>
                 ))}
               </div>

--- a/frontend/src/components/FixtureCard.css
+++ b/frontend/src/components/FixtureCard.css
@@ -50,6 +50,18 @@
 
 .team.away { flex-direction: row-reverse; text-align: right; }
 
+.team .team-name-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline dotted rgba(255,255,255,0.2);
+  transition: color 0.15s;
+}
+.team .team-name-btn:hover { color: var(--purple); }
+
 .crest { width: 26px; height: 26px; object-fit: contain; }
 
 .vs-block {

--- a/frontend/src/components/FixtureCard.jsx
+++ b/frontend/src/components/FixtureCard.jsx
@@ -23,7 +23,7 @@ function restLabel(days) {
   return { text: `${days}d`, cls: 'rest-normal' }
 }
 
-export default function FixtureCard({ prediction, showTipp11, blendOdds }) {
+export default function FixtureCard({ prediction, showTipp11, blendOdds, onTeamClick }) {
   const { fixture, win_probabilities, expected_home_goals, expected_away_goals, most_likely_score, score_matrix, odds, edge_home_win, edge_draw, edge_away_win,
     rest_days_home, rest_days_away, travel_km } = prediction
 
@@ -58,7 +58,7 @@ export default function FixtureCard({ prediction, showTipp11, blendOdds }) {
       <div className="teams-row">
         <div className="team home">
           {home_team.crest_url && <img src={home_team.crest_url} alt="" className="crest" />}
-          <span>{home_team.name}</span>
+          <button className="team-name-btn" onClick={() => onTeamClick?.(home_team.name)}>{home_team.name}</button>
         </div>
         <div className="vs-block">
           {actualScore ? (
@@ -86,7 +86,7 @@ export default function FixtureCard({ prediction, showTipp11, blendOdds }) {
         </div>
         <div className="team away">
           {away_team.crest_url && <img src={away_team.crest_url} alt="" className="crest" />}
-          <span>{away_team.name}</span>
+          <button className="team-name-btn" onClick={() => onTeamClick?.(away_team.name)}>{away_team.name}</button>
         </div>
       </div>
 

--- a/frontend/src/components/LeagueTable.css
+++ b/frontend/src/components/LeagueTable.css
@@ -102,6 +102,19 @@
 .zb-playoff { background: var(--red); opacity: 0.75; }
 .zb-rel     { background: #b71c1c; }
 
+.team-name-btn {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+  text-align: left;
+  text-decoration: underline dotted rgba(255,255,255,0.25);
+  transition: color 0.15s;
+}
+.team-name-btn:hover { color: var(--purple); }
+
 /* Form pips */
 .form-pips { display: flex; gap: 2px; justify-content: flex-end; }
 .pip { width: 8px; height: 8px; border-radius: 50%; display: inline-block; }

--- a/frontend/src/components/LeagueTable.jsx
+++ b/frontend/src/components/LeagueTable.jsx
@@ -65,7 +65,7 @@ function ZoneBar({ sim }) {
   )
 }
 
-export default function LeagueTable() {
+export default function LeagueTable({ onTeamClick }) {
   const [table, setTable]     = useState([])
   const [simMap, setSimMap]   = useState({})
   const [loading, setLoading] = useState(true)
@@ -147,7 +147,7 @@ export default function LeagueTable() {
               <td className="col-pos">{row.position}</td>
               <td className="col-team">
                 {row.team.crest_url && <img src={row.team.crest_url} className="table-crest" alt="" />}
-                <span>{row.team.short_name}</span>
+                <button className="team-name-btn" onClick={() => onTeamClick?.(row.team.name)}>{row.team.short_name}</button>
               </td>
               <td>{row.played}</td>
               <td>{row.won}</td>

--- a/frontend/src/components/TeamProfile.css
+++ b/frontend/src/components/TeamProfile.css
@@ -1,0 +1,184 @@
+.tp-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  z-index: 200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.tp-modal {
+  background: var(--bg-card, #1e1e2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  width: min(680px, 100%);
+  max-height: 85vh;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+}
+
+.tp-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tp-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin: 0;
+  color: var(--accent, #6c63ff);
+}
+
+.tp-close {
+  background: none;
+  border: none;
+  color: var(--text-muted, #888);
+  font-size: 1.1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  transition: color 0.15s;
+}
+.tp-close:hover { color: var(--text, #fff); }
+
+.tp-status {
+  color: var(--text-muted, #888);
+  padding: 1rem 0;
+  text-align: center;
+}
+.tp-error { color: #e8000f; }
+
+.tp-section-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted, #888);
+  margin: 0 0 0.75rem;
+}
+
+/* --- Rating bars --- */
+.rating-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.55rem;
+}
+
+.rating-label {
+  width: 9rem;
+  font-size: 0.8rem;
+  color: var(--text-muted, #aaa);
+  flex-shrink: 0;
+}
+
+.rating-track {
+  flex: 1;
+  height: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 5px;
+  position: relative;
+  overflow: visible;
+}
+
+.rating-fill {
+  height: 100%;
+  border-radius: 5px;
+  transition: width 0.3s ease;
+}
+.rating-fill.above-avg { background: #4caf50; }
+.rating-fill.below-avg { background: #e8000f; }
+
+.rating-avg-mark {
+  position: absolute;
+  top: -3px;
+  bottom: -3px;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 1px;
+  transform: translateX(-50%);
+}
+
+.rating-value {
+  width: 7rem;
+  font-size: 0.78rem;
+  text-align: right;
+  flex-shrink: 0;
+}
+.rating-value.pos { color: #4caf50; }
+.rating-value.neg { color: #e8000f; }
+
+.rating-diff {
+  color: var(--text-muted, #888);
+  font-size: 0.7rem;
+}
+
+.tp-bayes-note {
+  font-size: 0.72rem;
+  color: var(--text-muted, #888);
+  margin-top: 0.25rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.07);
+}
+
+/* --- Tables --- */
+.tp-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8rem;
+}
+
+.tp-table th {
+  text-align: left;
+  font-weight: 600;
+  font-size: 0.7rem;
+  color: var(--text-muted, #888);
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.tp-table td {
+  padding: 0.35rem 0.4rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  color: var(--text, #eee);
+}
+
+.tp-table tbody tr:last-child td { border-bottom: none; }
+
+.tp-date  { color: var(--text-muted, #888); white-space: nowrap; }
+.tp-score { font-weight: 700; white-space: nowrap; }
+.tp-opponent { font-weight: 500; }
+.tp-team-cell { }
+.tp-team-cell.is-this-team { font-weight: 700; color: var(--accent, #6c63ff); }
+
+.tp-ha {
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 0.1rem 0.3rem;
+  border-radius: 3px;
+}
+.tp-ha.home { background: rgba(76, 175, 80, 0.15); color: #4caf50; }
+.tp-ha.away { background: rgba(232, 0, 15, 0.12); color: #e8000f; }
+
+.tp-prob { font-variant-numeric: tabular-nums; }
+.tp-xg   { font-variant-numeric: tabular-nums; color: var(--text-muted, #aaa); }
+
+.result-badge {
+  display: inline-block;
+  width: 1.4rem;
+  text-align: center;
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: 3px;
+  padding: 0.1rem 0;
+}
+.result-W { background: rgba(76, 175, 80, 0.2); color: #4caf50; }
+.result-D { background: rgba(255, 193, 7, 0.2); color: #ffc107; }
+.result-L { background: rgba(232, 0, 15, 0.15); color: #e8000f; }

--- a/frontend/src/components/TeamProfile.jsx
+++ b/frontend/src/components/TeamProfile.jsx
@@ -1,0 +1,163 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import './TeamProfile.css'
+
+function RatingBar({ label, value, avg, higherIsBetter = true }) {
+  const pct = Math.min(value / (avg * 2), 1) * 100
+  const avgPct = 50
+  const better = higherIsBetter ? value > avg : value < avg
+  const diff = ((value - avg) / avg * 100).toFixed(1)
+  const sign = diff > 0 ? '+' : ''
+
+  return (
+    <div className="rating-row">
+      <span className="rating-label">{label}</span>
+      <div className="rating-track">
+        <div
+          className={`rating-fill ${better ? 'above-avg' : 'below-avg'}`}
+          style={{ width: `${pct}%` }}
+        />
+        <div className="rating-avg-mark" style={{ left: `${avgPct}%` }} title="League avg" />
+      </div>
+      <span className={`rating-value ${better ? 'pos' : 'neg'}`}>
+        {value.toFixed(3)} <span className="rating-diff">({sign}{diff}%)</span>
+      </span>
+    </div>
+  )
+}
+
+function ResultBadge({ homeTeam, homeGoals, awayGoals, team }) {
+  const isHome = homeTeam === team
+  const scored = isHome ? homeGoals : awayGoals
+  const conceded = isHome ? awayGoals : homeGoals
+  const result = scored > conceded ? 'W' : scored < conceded ? 'L' : 'D'
+  return <span className={`result-badge result-${result}`}>{result}</span>
+}
+
+export default function TeamProfile({ teamName, onClose }) {
+  const [profile, setProfile] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    if (!teamName) return
+    let cancelled = false
+    axios.get(`/api/teams/${encodeURIComponent(teamName)}`)
+      .then(res => { if (!cancelled) { setProfile(res.data); setError(null); setLoading(false) } })
+      .catch(err => { if (!cancelled) { setError(err.response?.data?.detail ?? err.message); setLoading(false) } })
+    return () => { cancelled = true }
+  }, [teamName])
+
+  useEffect(() => {
+    function handleKey(e) { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  return (
+    <div className="tp-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
+      <div className="tp-modal" role="dialog" aria-modal="true" aria-label={`Team profile: ${teamName}`}>
+        <div className="tp-header">
+          <h2 className="tp-title">{teamName}</h2>
+          <button className="tp-close" onClick={onClose} aria-label="Close">✕</button>
+        </div>
+
+        {loading && <div className="tp-status">Loading…</div>}
+        {error   && <div className="tp-status tp-error">{error}</div>}
+
+        {profile && (
+          <>
+            <section className="tp-section">
+              <h3 className="tp-section-title">Model ratings</h3>
+              <RatingBar label="Attack (α)" value={profile.alpha} avg={profile.avg_alpha} higherIsBetter={true} />
+              <RatingBar label="Defence (δ)" value={profile.delta} avg={profile.avg_delta} higherIsBetter={false} />
+              <RatingBar label="Home adv (γ)" value={profile.gamma} avg={profile.avg_gamma} higherIsBetter={true} />
+              <RatingBar label="Form" value={profile.form} avg={profile.avg_form} higherIsBetter={true} />
+              {profile.bayes_fitted && profile.alpha_bayes != null && (
+                <div className="tp-bayes-note">
+                  Bayes α: {profile.alpha_bayes.toFixed(3)} · δ: {profile.delta_bayes.toFixed(3)}
+                </div>
+              )}
+            </section>
+
+            {profile.upcoming.length > 0 && (
+              <section className="tp-section">
+                <h3 className="tp-section-title">Upcoming fixtures</h3>
+                <table className="tp-table">
+                  <thead>
+                    <tr>
+                      <th>MD</th>
+                      <th>Date</th>
+                      <th>Opponent</th>
+                      <th>H/A</th>
+                      <th>Win%</th>
+                      <th>Draw%</th>
+                      <th>xG</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {profile.upcoming.map(f => {
+                      const isHome = f.home_team === profile.team
+                      const opponent = isHome ? f.away_team : f.home_team
+                      const winProb = isHome ? f.home_win_prob : f.away_win_prob
+                      const xgFor = isHome ? f.expected_home_goals : f.expected_away_goals
+                      const xgAgainst = isHome ? f.expected_away_goals : f.expected_home_goals
+                      const date = new Date(f.date).toLocaleDateString('en-GB', { weekday: 'short', day: 'numeric', month: 'short' })
+                      return (
+                        <tr key={f.fixture_id}>
+                          <td>{f.matchday}</td>
+                          <td className="tp-date">{date}</td>
+                          <td className="tp-opponent">{opponent}</td>
+                          <td className={`tp-ha ${isHome ? 'home' : 'away'}`}>{isHome ? 'H' : 'A'}</td>
+                          <td className="tp-prob">{(winProb * 100).toFixed(0)}%</td>
+                          <td className="tp-prob">{(f.draw_prob * 100).toFixed(0)}%</td>
+                          <td className="tp-xg">{xgFor.toFixed(2)}–{xgAgainst.toFixed(2)}</td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </section>
+            )}
+
+            {profile.season_results.length > 0 && (
+              <section className="tp-section">
+                <h3 className="tp-section-title">This season</h3>
+                <table className="tp-table">
+                  <thead>
+                    <tr>
+                      <th>MD</th>
+                      <th>Date</th>
+                      <th>Home</th>
+                      <th></th>
+                      <th>Away</th>
+                      <th></th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {profile.season_results.map((r, i) => (
+                      <tr key={i}>
+                        <td>{r.matchday ?? '—'}</td>
+                        <td className="tp-date">{r.date}</td>
+                        <td className={`tp-team-cell ${r.home_team === profile.team ? 'is-this-team' : ''}`}>{r.home_team}</td>
+                        <td className="tp-score">{r.home_goals}–{r.away_goals}</td>
+                        <td className={`tp-team-cell ${r.away_team === profile.team ? 'is-this-team' : ''}`}>{r.away_team}</td>
+                        <td>
+                          <ResultBadge
+                            homeTeam={r.home_team}
+                            homeGoals={r.home_goals} awayGoals={r.away_goals}
+                            team={profile.team}
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </section>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #16

## What's added

**Backend — `GET /api/teams/{team_name}`**
- Case-insensitive team lookup; 404 if not found, 503 if model not fitted
- Returns model parameters (α attack, δ defence, γ home advantage, form) alongside league averages for relative comparison
- Includes Bayesian model params when available
- Current-season results filtered from training data
- Upcoming scheduled fixtures with win/draw probabilities and xG from the base model

**Frontend — `TeamProfile` modal**
- **Model ratings section** — bar gauges for α, δ, γ, and form; green = above league average, red = below; percentage diff shown
- **Upcoming fixtures table** — matchday, date, opponent, H/A, win%, draw%, xG
- **Season results table** — all current-season matches with score, opponent highlighted, W/D/L badge
- Escape key and backdrop click to dismiss
- Team names in `FixtureCard` and `LeagueTable` are now clickable (dotted underline on hover) and open the profile modal

## Test plan
- [ ] Click a team name in a fixture card → modal opens with correct data
- [ ] Click a team name in the league table → modal opens
- [ ] Escape / backdrop click closes the modal
- [ ] Rating bars reflect above/below average correctly (green/red)
- [ ] Upcoming fixtures show H/A correctly from the team's perspective
- [ ] Season results show correct W/D/L badges
- [ ] 404 returned for unknown team name

🤖 Generated with [Claude Code](https://claude.ai/claude-code)