### PR TITLE
Live score auto-refresh + fix all lint errors (#24)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -226,6 +226,7 @@
 /* Live dot */
 .live-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--text-muted); flex-shrink: 0; }
 .live-dot.pulsing { background: var(--green); animation: pulse 1.4s ease-in-out infinite; }
+.live-updated { font-size: var(--text-xxs); color: var(--green); opacity: 0.7; white-space: nowrap; }
 
 @keyframes pulse {
   0%, 100% { opacity: 1; transform: scale(1); }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -126,8 +126,8 @@ function MatchupSidebar({ predictions, onSelect, blendOdds }) {
 }
 
 export default function App() {
-  const [allPredictions, setAllPredictions] = useState([])
-  const [groups, setGroups] = useState([])
+  // variant tracks which model the current predictions came from; loading derived from mismatch
+  const [fetchState, setFetchState] = useState({ variant: null, predictions: [], error: null })
   const [selectedMatchday, setSelectedMatchday] = useState(null)
   const [liveOnly, setLiveOnly] = useState(false)
   const [selectedTeam, setSelectedTeam] = useState('')
@@ -139,22 +139,14 @@ export default function App() {
   const [showBacktest, setShowBacktest] = useState(false)
   const [modelVariant, setModelVariant] = useState('base')
   const [bayesPredictions, setBayesPredictions] = useState([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState(null)
   const [profileTeam, setProfileTeam] = useState(null)
+  const [lastUpdated, setLastUpdated] = useState(null)
 
-  useEffect(() => {
-    axios.get(`/api/predictions/upcoming?model_variant=${modelVariant}`)
-      .then(res => {
-        const preds = res.data
-        const g = groupByMatchday(preds)
-        setAllPredictions(preds)
-        setGroups(g)
-        setSelectedMatchday(defaultMatchday(g))
-      })
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false))
-  }, [])
+  const allPredictions = fetchState.predictions
+  const loading = fetchState.variant !== modelVariant
+  const error = fetchState.error
+
+  const groups = useMemo(() => groupByMatchday(allPredictions), [allPredictions])
 
   const teams = useMemo(() => {
     const s = new Set()
@@ -171,6 +163,7 @@ export default function App() {
   )
 
   const visiblePredictions = useMemo(() => {
+    if (loading) return []
     let preds = allPredictions
 
     if (liveOnly) {
@@ -187,23 +180,16 @@ export default function App() {
     }
 
     return preds
-  }, [allPredictions, groups, selectedMatchday, liveOnly, selectedTeam])
+  }, [loading, allPredictions, groups, selectedMatchday, liveOnly, selectedTeam])
 
   useEffect(() => {
-    setAllPredictions([])
-    setGroups([])
-    setSelectedMatchday(null)
-    setLoading(true)
     axios.get(`/api/predictions/upcoming?model_variant=${modelVariant}`)
       .then(res => {
         const preds = res.data
-        const g = groupByMatchday(preds)
-        setAllPredictions(preds)
-        setGroups(g)
-        setSelectedMatchday(defaultMatchday(g))
+        setFetchState({ variant: modelVariant, predictions: preds, error: null })
+        setSelectedMatchday(defaultMatchday(groupByMatchday(preds)))
       })
-      .catch(err => setError(err.message))
-      .finally(() => setLoading(false))
+      .catch(err => setFetchState({ variant: modelVariant, predictions: [], error: err.message }))
   }, [modelVariant])
 
   // Fetch Bayes predictions for side-by-side Tipp 11 comparison
@@ -213,6 +199,20 @@ export default function App() {
       .then(res => setBayesPredictions(res.data))
       .catch(() => setBayesPredictions([]))
   }, [showTipp11])
+
+  // Auto-refresh every 60s while at least one game is live
+  useEffect(() => {
+    if (liveCount === 0) return
+    const id = setInterval(() => {
+      axios.get(`/api/predictions/upcoming?model_variant=${modelVariant}`)
+        .then(res => {
+          setFetchState(prev => ({ ...prev, predictions: res.data }))
+          setLastUpdated(new Date())
+        })
+        .catch(() => {})
+    }, 60_000)
+    return () => clearInterval(id)
+  }, [liveCount, modelVariant])
 
   function toggleFavorite() {
     if (favoriteTeam === selectedTeam) {
@@ -266,6 +266,11 @@ export default function App() {
                 <span className={`live-dot${liveCount > 0 ? ' pulsing' : ''}`} />
                 Live{liveCount > 0 ? ` (${liveCount})` : ''}
               </button>
+              {liveCount > 0 && lastUpdated && (
+                <span className="live-updated">
+                  ↻ {lastUpdated.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                </span>
+              )}
 
               <div className="filter-separator" />
 

--- a/frontend/src/components/CalibrationView.jsx
+++ b/frontend/src/components/CalibrationView.jsx
@@ -280,7 +280,7 @@ export default function CalibrationView() {
                 const da = params.bayes_fitted ? t.alpha_bayes - t.alpha_base : null
                 const dd = params.bayes_fitted ? t.delta_bayes - t.delta_base : null
                 const dg = params.bayes_fitted ? t.gamma_bayes - t.gamma_base : null
-                const delta = (v, cls) => v == null ? null : (
+                const delta = (v) => v == null ? null : (
                   <td className={`cal-delta ${v > 0.005 ? 'good' : v < -0.005 ? 'bad' : ''}`}>
                     {v > 0 ? '+' : ''}{v.toFixed(3)}
                   </td>

--- a/frontend/src/components/LeagueTable.jsx
+++ b/frontend/src/components/LeagueTable.jsx
@@ -26,6 +26,15 @@ function FormPips({ form }) {
   )
 }
 
+function SortHeader({ label, k, sortKey, sortDir, onSort }) {
+  const active = sortKey === k
+  return (
+    <th className={`sortable${active ? ' active' : ''}`} onClick={() => onSort(k)}>
+      {label}{active ? (sortDir === 1 ? ' ↑' : ' ↓') : ''}
+    </th>
+  )
+}
+
 function ZoneBar({ sim }) {
   if (!sim) return <span className="zone-bar-placeholder">—</span>
 
@@ -101,15 +110,6 @@ export default function LeagueTable({ onTeamClick }) {
     return sortDir * (typeof av === 'string' ? av.localeCompare(bv) : av - bv)
   })
 
-  function SortHeader({ label, k }) {
-    const active = sortKey === k
-    return (
-      <th className={`sortable${active ? ' active' : ''}`} onClick={() => handleSort(k)}>
-        {label}{active ? (sortDir === 1 ? ' ↑' : ' ↓') : ''}
-      </th>
-    )
-  }
-
   if (loading) return <div className="status">Loading table…</div>
   if (error)   return <div className="status error">Error: {error}</div>
 
@@ -125,17 +125,17 @@ export default function LeagueTable({ onTeamClick }) {
       <table className="league-table">
         <thead>
           <tr>
-            <SortHeader label="#"   k="position" />
+            <SortHeader label="#"   k="position" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
             <th>Team</th>
-            <SortHeader label="P"   k="played" />
-            <SortHeader label="W"   k="won" />
-            <SortHeader label="D"   k="draw" />
-            <SortHeader label="L"   k="lost" />
-            <SortHeader label="GD"  k="goal_difference" />
-            <SortHeader label="Pts" k="points" />
+            <SortHeader label="P"   k="played"   sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="W"   k="won"      sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="D"   k="draw"     sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="L"   k="lost"     sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="GD"  k="goal_difference" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="Pts" k="points"   sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
             <th className="col-form">Form</th>
-            <SortHeader label="xPts left" k="expected_pts_remaining" />
-            <SortHeader label="Projected"  k="projected_total" />
+            <SortHeader label="xPts left" k="expected_pts_remaining" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
+            <SortHeader label="Projected" k="projected_total"        sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
             <th className="col-finish" title="Monte Carlo season finish probabilities (10 000 simulations)">
               Finish zones {simReady ? '' : '…'}
             </th>


### PR DESCRIPTION
## Summary

**Issue #24 — Live auto-refresh:**
- Polls `/api/predictions/upcoming` every 60s while at least one fixture is `IN_PLAY` / `PAUSED` / `LIVE`
- Interval starts and stops automatically based on `liveCount`; no wasted requests when nothing is live
- Shows a `↻ HH:MM` last-updated timestamp next to the Live button once the first poll fires
- Selected matchday and expanded card state are preserved across polls

**Pre-existing lint errors (all now clean):**
- `App.jsx` — two `useEffect` issues: removed the redundant mount-only effect; consolidated `allPredictions`/`loading`/`error` into a single `fetchState` object and derive `loading = fetchState.variant !== modelVariant`, so `loading` flips to `true` immediately on model change without any synchronous `setState` in an effect body. Made `groups` a `useMemo`.
- `CalibrationView.jsx` — removed unused `cls` parameter from the `delta` arrow function
- `LeagueTable.jsx` — lifted `SortHeader` out of the render function; passes `sortKey`, `sortDir`, `onSort` as props

## Test plan

- [ ] `npm run lint` — no errors
- [ ] During a live matchday, confirm the `↻ HH:MM` badge appears and updates each minute
- [ ] Toggle model variant — confirm loading state shows immediately, then new predictions load
- [ ] Sort columns in League Table still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)