### PR TITLE
Closing Line Value (CLV) tracker (#26)

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 import asyncio
 import logging
 
-from app.routers import fixtures, predictions, table, calibration, model_params, backtest as backtest_router, simulation as simulation_router, teams as teams_router, h2h as h2h_router, odds as odds_router, picks as picks_router
+from app.routers import fixtures, predictions, table, calibration, model_params, backtest as backtest_router, simulation as simulation_router, teams as teams_router, h2h as h2h_router, odds as odds_router, picks as picks_router, clv as clv_router
 from app.services import backtest as backtest_service
 from app.services import odds_history, user_picks
 from app.services.dixon_coles import get_model, get_model_bayes
@@ -89,10 +89,6 @@ async def _snapshot_current_odds(fixtures, odds_map) -> None:
             odds_history.record_snapshot(fixture.id, match_odds)
             count += 1
     logger.info("Odds snapshots recorded for %d fixtures", count)
-
-    settled = {f.id for f in fixtures if f.status in ("FINISHED", "AWARDED")}
-    if settled:
-        odds_history.prune(settled)
 
 
 async def _poll_odds_and_snapshot() -> None:
@@ -210,6 +206,7 @@ app.include_router(teams_router.router, prefix="/api")
 app.include_router(h2h_router.router, prefix="/api")
 app.include_router(odds_router.router, prefix="/api")
 app.include_router(picks_router.router, prefix="/api")
+app.include_router(clv_router.router, prefix="/api")
 
 
 @app.get("/api/health")

--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -245,6 +245,46 @@ class UserPickRequest(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Closing line value (CLV)
+# ---------------------------------------------------------------------------
+
+class CLVEntry(BaseModel):
+    fixture_id: int
+    matchday: int
+    home_team: str
+    away_team: str
+    utc_date: str
+    home_score: Optional[int] = None
+    away_score: Optional[int] = None
+
+    model_home_prob: float
+    model_draw_prob: float
+    model_away_prob: float
+
+    opening_home_prob: Optional[float] = None
+    opening_draw_prob: Optional[float] = None
+    opening_away_prob: Optional[float] = None
+
+    closing_home_prob: Optional[float] = None
+    closing_draw_prob: Optional[float] = None
+    closing_away_prob: Optional[float] = None
+
+    clv_home: Optional[float] = None
+    clv_draw: Optional[float] = None
+    clv_away: Optional[float] = None
+
+    best_outcome: str          # "home" | "draw" | "away"
+    best_clv: Optional[float] = None
+
+
+class CLVResponse(BaseModel):
+    entries: list[CLVEntry]
+    avg_best_clv: Optional[float] = None
+    fixtures_with_closing: int
+    fixtures_total: int
+
+
+# ---------------------------------------------------------------------------
 # Odds movement
 # ---------------------------------------------------------------------------
 

--- a/backend/app/routers/clv.py
+++ b/backend/app/routers/clv.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter
+from app.services import prediction_cache, prediction_cache_bayes, odds_history
+from app.models.schemas import CLVEntry, CLVResponse
+
+router = APIRouter(prefix="/clv", tags=["clv"])
+
+
+@router.get("", response_model=CLVResponse)
+async def get_clv(model_variant: str = "base"):
+    """
+    Closing line value for all settled fixtures.
+    CLV = model implied probability - closing bookmaker implied probability.
+    Positive CLV means the model assigned more probability than the market's
+    final efficient price — the gold standard for a predictive edge.
+    """
+    cache = prediction_cache_bayes if model_variant == "bayes" else prediction_cache
+    entries: list[CLVEntry] = []
+
+    for fixture_id, pred in cache.get_all().items():
+        fixture = pred.fixture
+        if fixture.status not in ("FINISHED", "AWARDED"):
+            continue
+
+        wp = pred.win_probabilities
+        probs = {"home": wp.home_win, "draw": wp.draw, "away": wp.away_win}
+        best_outcome = max(probs, key=probs.__getitem__)
+
+        kickoff = fixture.utc_date.isoformat()
+        opening = odds_history.get_opening_snapshot(fixture_id)
+        closing = odds_history.get_closing_snapshot(fixture_id, kickoff)
+
+        open_h = opening.implied_home_prob if opening else None
+        open_d = opening.implied_draw_prob if opening else None
+        open_a = opening.implied_away_prob if opening else None
+
+        close_h = closing.implied_home_prob if closing else None
+        close_d = closing.implied_draw_prob if closing else None
+        close_a = closing.implied_away_prob if closing else None
+
+        clv_home = clv_draw = clv_away = best_clv = None
+        if closing and close_h is not None:
+            clv_home = round(wp.home_win - close_h, 4)
+            clv_draw = round(wp.draw - close_d, 4)
+            clv_away = round(wp.away_win - close_a, 4)
+            best_clv = {"home": clv_home, "draw": clv_draw, "away": clv_away}[best_outcome]
+
+        entries.append(CLVEntry(
+            fixture_id=fixture_id,
+            matchday=fixture.matchday,
+            home_team=fixture.home_team.name,
+            away_team=fixture.away_team.name,
+            utc_date=kickoff,
+            home_score=fixture.home_score,
+            away_score=fixture.away_score,
+            model_home_prob=round(wp.home_win, 4),
+            model_draw_prob=round(wp.draw, 4),
+            model_away_prob=round(wp.away_win, 4),
+            opening_home_prob=open_h,
+            opening_draw_prob=open_d,
+            opening_away_prob=open_a,
+            closing_home_prob=close_h,
+            closing_draw_prob=close_d,
+            closing_away_prob=close_a,
+            clv_home=clv_home,
+            clv_draw=clv_draw,
+            clv_away=clv_away,
+            best_outcome=best_outcome,
+            best_clv=best_clv,
+        ))
+
+    entries.sort(key=lambda e: (e.matchday, e.utc_date))
+
+    with_closing = [e for e in entries if e.best_clv is not None]
+    avg_best_clv = (
+        round(sum(e.best_clv for e in with_closing) / len(with_closing), 4)
+        if with_closing else None
+    )
+
+    return CLVResponse(
+        entries=entries,
+        avg_best_clv=avg_best_clv,
+        fixtures_with_closing=len(with_closing),
+        fixtures_total=len(entries),
+    )

--- a/backend/app/services/odds_history.py
+++ b/backend/app/services/odds_history.py
@@ -101,6 +101,22 @@ def get_history(fixture_id: int) -> list[OddsSnapshot]:
     return _snapshots.get(fixture_id, [])
 
 
+def get_opening_snapshot(fixture_id: int) -> OddsSnapshot | None:
+    snaps = _snapshots.get(fixture_id, [])
+    return snaps[0] if snaps else None
+
+
+def get_closing_snapshot(fixture_id: int, kickoff_utc: str) -> OddsSnapshot | None:
+    """Last snapshot recorded strictly before kickoff."""
+    snaps = _snapshots.get(fixture_id, [])
+    before = [s for s in snaps if s.timestamp < kickoff_utc]
+    return before[-1] if before else None
+
+
+def get_all_fixture_ids() -> list[int]:
+    return list(_snapshots.keys())
+
+
 def prune(fixture_ids: set[int]) -> None:
     """Remove snapshot history for settled fixtures from memory and DB."""
     removed = 0

--- a/backend/app/services/prediction_cache.py
+++ b/backend/app/services/prediction_cache.py
@@ -9,3 +9,7 @@ def get(fixture_id: int) -> Prediction | None:
 
 def set(fixture_id: int, prediction: Prediction) -> None:
     _cache[fixture_id] = prediction
+
+
+def get_all() -> dict[int, Prediction]:
+    return dict(_cache)

--- a/backend/app/services/prediction_cache_bayes.py
+++ b/backend/app/services/prediction_cache_bayes.py
@@ -9,3 +9,7 @@ def get(fixture_id: int) -> Prediction | None:
 
 def set(fixture_id: int, prediction: Prediction) -> None:
     _cache[fixture_id] = prediction
+
+
+def get_all() -> dict[int, Prediction]:
+    return dict(_cache)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import AccuracySummary from './components/AccuracySummary'
 import Tipp11Summary from './components/Tipp11Summary'
 import CalibrationView from './components/CalibrationView'
 import BacktestView from './components/BacktestView'
+import CLVView from './components/CLVView'
 import TeamProfile from './components/TeamProfile'
 import { blendScoreMatrix } from './utils/blendOdds'
 import { bestTipp11Tip } from './utils/tipp11'
@@ -137,6 +138,7 @@ export default function App() {
   const [showTable, setShowTable] = useState(false)
   const [showCalibration, setShowCalibration] = useState(false)
   const [showBacktest, setShowBacktest] = useState(false)
+  const [showCLV, setShowCLV] = useState(false)
   const [modelVariant, setModelVariant] = useState('base')
   const [bayesPredictions, setBayesPredictions] = useState([])
   const [profileTeam, setProfileTeam] = useState(null)
@@ -233,8 +235,8 @@ export default function App() {
       <AppHeader />
       {profileTeam && <TeamProfile teamName={profileTeam} onClose={() => setProfileTeam(null)} />}
 
-      <div className={`app-body${showTable || showCalibration || showBacktest ? ' no-sidebar' : ''}`}>
-        {visiblePredictions.length > 0 && !showTable && !showCalibration && !showBacktest && (
+      <div className={`app-body${showTable || showCalibration || showBacktest || showCLV ? ' no-sidebar' : ''}`}>
+        {visiblePredictions.length > 0 && !showTable && !showCalibration && !showBacktest && !showCLV && (
           <MatchupSidebar predictions={visiblePredictions} onSelect={scrollToFixture} blendOdds={blendOdds} />
         )}
 
@@ -314,6 +316,14 @@ export default function App() {
                 Backtest
               </button>
 
+              <button
+                className={`filter-btn${showCLV ? ' view-active' : ''}`}
+                onClick={() => setShowCLV(v => !v)}
+                title="Closing Line Value — model vs. market's final price"
+              >
+                CLV
+              </button>
+
               <div className="filter-separator" />
 
               {/* Group 4: model selector */}
@@ -352,8 +362,8 @@ export default function App() {
             </div>
           )}
 
-          {!showTable && !showCalibration && !showBacktest && <AccuracySummary predictions={visiblePredictions} />}
-          {!showTable && !showCalibration && !showBacktest && showTipp11 && (
+          {!showTable && !showCalibration && !showBacktest && !showCLV && <AccuracySummary predictions={visiblePredictions} />}
+          {!showTable && !showCalibration && !showBacktest && !showCLV && showTipp11 && (
             <Tipp11Summary
               predictions={visiblePredictions}
               bayesPredictions={bayesPredictions}
@@ -361,7 +371,9 @@ export default function App() {
             />
           )}
 
-          {showBacktest ? (
+          {showCLV ? (
+            <CLVView modelVariant={modelVariant} />
+          ) : showBacktest ? (
             <BacktestView />
           ) : showCalibration ? (
             <CalibrationView />

--- a/frontend/src/components/CLVView.css
+++ b/frontend/src/components/CLVView.css
@@ -1,0 +1,149 @@
+.clv-wrapper {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--r-card);
+  padding: 1.2rem 1.4rem;
+}
+
+.clv-header {
+  margin-bottom: 1rem;
+}
+
+.clv-title {
+  font-size: var(--text-base);
+  font-weight: 700;
+  color: var(--text-primary);
+  margin: 0 0 0.25rem;
+}
+
+.clv-desc {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  margin: 0;
+  max-width: 60ch;
+}
+
+/* Summary cards */
+.clv-cards {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1.2rem;
+  flex-wrap: wrap;
+}
+
+.clv-card {
+  flex: 1;
+  min-width: 140px;
+  background: var(--bg-input);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-card);
+  padding: 0.6rem 0.9rem;
+}
+
+.clv-card.highlight {
+  border-color: var(--green);
+  background: rgba(76, 175, 80, 0.05);
+}
+
+.clv-card-value {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.clv-card-label {
+  font-size: var(--text-xxs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-top: 0.1rem;
+}
+
+.clv-card-sub {
+  font-size: var(--text-xxs);
+  color: var(--text-dimmed);
+  margin-top: 0.15rem;
+}
+
+/* Notice */
+.clv-notice {
+  font-size: var(--text-xs);
+  color: var(--yellow);
+  background: rgba(255, 200, 0, 0.07);
+  border: 1px solid rgba(255, 200, 0, 0.2);
+  border-radius: var(--r-xs);
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+}
+
+/* Table */
+.clv-table-wrap {
+  overflow-x: auto;
+}
+
+.clv-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--text-sm);
+  white-space: nowrap;
+}
+
+.clv-table th {
+  color: var(--text-muted);
+  font-size: var(--text-xxs);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.2rem 0.4rem;
+  border-bottom: 1px solid var(--border-subtle);
+  text-align: right;
+}
+
+.clv-table th:first-child,
+.clv-fix-hdr { text-align: left; }
+
+.clv-group-hdr {
+  border-left: 1px solid var(--border-subtle);
+  padding-left: 0.6rem;
+}
+
+.clv-sub-hdr th {
+  font-size: 9px;
+  padding-top: 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.clv-table td {
+  padding: 0.3rem 0.4rem;
+  border-bottom: 1px solid var(--border-subtle);
+  text-align: right;
+  color: var(--text-secondary);
+}
+
+.clv-table tbody tr:last-child td { border-bottom: none; }
+.clv-table tbody tr:hover td { background: rgba(255,255,255,0.02); }
+
+.clv-md      { color: var(--text-muted); font-size: var(--text-xxs); text-align: center; }
+.clv-fixture { text-align: left; color: var(--text-primary); font-weight: 600; }
+.clv-result  { color: var(--text-muted); }
+.clv-prob    { color: var(--text-secondary); }
+.clv-prob.muted { color: var(--text-dimmed); }
+
+/* CLV colouring */
+.clv-pos  { color: var(--green); font-weight: 700; }
+.clv-neg  { color: var(--red); }
+.clv-flat { color: var(--text-muted); }
+.clv-none { color: var(--text-dimmed); }
+
+/* Best pick column */
+.clv-best { font-weight: 700; color: var(--text-primary); }
+.clv-best-home { color: var(--green); }
+.clv-best-draw { color: var(--yellow); }
+.clv-best-away { color: var(--purple); }
+
+.clv-best-val {
+  font-size: var(--text-xxs);
+  font-weight: 400;
+  margin-left: 0.25rem;
+}

--- a/frontend/src/components/CLVView.jsx
+++ b/frontend/src/components/CLVView.jsx
@@ -1,0 +1,146 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+import './CLVView.css'
+
+const OUTCOME_LABEL = { home: 'Home', draw: 'Draw', away: 'Away' }
+
+function pct(v) {
+  return v == null ? '–' : `${(v * 100).toFixed(1)}%`
+}
+
+function clvClass(v) {
+  if (v == null) return 'clv-none'
+  if (v > 0.01)  return 'clv-pos'
+  if (v < -0.01) return 'clv-neg'
+  return 'clv-flat'
+}
+
+function clvFmt(v) {
+  if (v == null) return '–'
+  return `${v > 0 ? '+' : ''}${(v * 100).toFixed(1)}pp`
+}
+
+function SummaryCard({ label, value, sub, highlight }) {
+  return (
+    <div className={`clv-card${highlight ? ' highlight' : ''}`}>
+      <div className="clv-card-value">{value}</div>
+      <div className="clv-card-label">{label}</div>
+      {sub && <div className="clv-card-sub">{sub}</div>}
+    </div>
+  )
+}
+
+export default function CLVView({ modelVariant = 'base' }) {
+  const [fetchState, setFetchState] = useState({ variant: null, data: null, error: null })
+  const loading = fetchState.variant !== modelVariant
+  const data  = fetchState.data
+  const error = fetchState.error
+
+  useEffect(() => {
+    axios.get(`/api/clv?model_variant=${modelVariant}`)
+      .then(r => setFetchState({ variant: modelVariant, data: r.data, error: null }))
+      .catch(e => setFetchState({ variant: modelVariant, data: null, error: e.message }))
+  }, [modelVariant])
+
+  if (loading) return <div className="status">Loading CLV data…</div>
+  if (error)   return <div className="status error">Error: {error}</div>
+  if (!data)   return null
+
+  const { entries, avg_best_clv, fixtures_with_closing, fixtures_total } = data
+  const noOdds = fixtures_with_closing === 0
+
+  return (
+    <div className="clv-wrapper">
+      <div className="clv-header">
+        <div>
+          <h2 className="clv-title">Closing Line Value</h2>
+          <p className="clv-desc">
+            CLV = model probability − closing implied probability.
+            Positive means the model assigned more probability than the market's final efficient price.
+          </p>
+        </div>
+      </div>
+
+      <div className="clv-cards">
+        <SummaryCard
+          label="Avg CLV (best pick)"
+          value={avg_best_clv != null ? clvFmt(avg_best_clv) : '–'}
+          sub={`${fixtures_with_closing} fixture${fixtures_with_closing !== 1 ? 's' : ''} with closing odds`}
+          highlight={avg_best_clv != null && avg_best_clv > 0}
+        />
+        <SummaryCard
+          label="Fixtures in cache"
+          value={fixtures_total}
+          sub="settled fixtures with frozen predictions"
+        />
+        <SummaryCard
+          label="Coverage"
+          value={fixtures_total > 0 ? `${Math.round(fixtures_with_closing / fixtures_total * 100)}%` : '–'}
+          sub="have closing odds"
+        />
+      </div>
+
+      {noOdds && (
+        <div className="clv-notice">
+          No closing odds yet — CLV data builds up over time as the odds poller runs before each kickoff.
+          Opening odds are stored on startup; closing odds accumulate with subsequent polls.
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="status">No settled fixtures in prediction cache yet.</div>
+      ) : (
+        <div className="clv-table-wrap">
+          <table className="clv-table">
+            <thead>
+              <tr>
+                <th>MD</th>
+                <th className="clv-fix-hdr">Fixture</th>
+                <th>Result</th>
+                <th className="clv-group-hdr" colSpan={3}>Model %</th>
+                <th className="clv-group-hdr" colSpan={3}>Closing %</th>
+                <th className="clv-group-hdr" colSpan={3}>CLV</th>
+                <th>Best pick</th>
+              </tr>
+              <tr className="clv-sub-hdr">
+                <th /><th /><th />
+                <th>H</th><th>D</th><th>A</th>
+                <th>H</th><th>D</th><th>A</th>
+                <th>H</th><th>D</th><th>A</th>
+                <th />
+              </tr>
+            </thead>
+            <tbody>
+              {entries.map(e => (
+                <tr key={e.fixture_id} className={e.home_score != null ? 'settled' : ''}>
+                  <td className="clv-md">{e.matchday}</td>
+                  <td className="clv-fixture">
+                    {e.home_team.split(' ').pop()} – {e.away_team.split(' ').pop()}
+                  </td>
+                  <td className="clv-result">
+                    {e.home_score != null ? `${e.home_score}–${e.away_score}` : '–'}
+                  </td>
+                  <td className="clv-prob">{pct(e.model_home_prob)}</td>
+                  <td className="clv-prob">{pct(e.model_draw_prob)}</td>
+                  <td className="clv-prob">{pct(e.model_away_prob)}</td>
+                  <td className="clv-prob muted">{pct(e.closing_home_prob)}</td>
+                  <td className="clv-prob muted">{pct(e.closing_draw_prob)}</td>
+                  <td className="clv-prob muted">{pct(e.closing_away_prob)}</td>
+                  <td className={clvClass(e.clv_home)}>{clvFmt(e.clv_home)}</td>
+                  <td className={clvClass(e.clv_draw)}>{clvFmt(e.clv_draw)}</td>
+                  <td className={clvClass(e.clv_away)}>{clvFmt(e.clv_away)}</td>
+                  <td className={`clv-best clv-best-${e.best_outcome}`}>
+                    {OUTCOME_LABEL[e.best_outcome]}
+                    {e.best_clv != null && (
+                      <span className={`clv-best-val ${clvClass(e.best_clv)}`}> {clvFmt(e.best_clv)}</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **`GET /api/clv?model_variant=base|bayes`** — new endpoint that iterates all settled fixtures in the prediction cache, finds the closing odds snapshot (last snapshot recorded before kickoff), and computes CLV = model probability − closing implied probability per outcome
- **CLVView** — new tab in the filter bar showing a summary (avg CLV, fixture count, coverage %) and a per-fixture table with model %, closing %, and colour-coded CLV columns (green = model beats market, red = market ahead)
- **Prune removed** — odds snapshots for settled fixtures are no longer deleted, so closing odds survive kickoff for CLV computation. The dataset stays small (~few KB/season)
- **`get_opening_snapshot` / `get_closing_snapshot`** added to `odds_history.py`; **`get_all()`** added to both prediction caches

## Degrading gracefully
- If only one snapshot exists (opening = closing), CLV vs closing equals CLV vs opening — still valid, just less informative
- If no odds history at all, the view shows a friendly notice explaining that data builds up as the odds poller runs

## Test plan

- [ ] Backend starts cleanly; `GET /api/clv` returns 200 (empty list on cold cache)
- [ ] After requesting `/api/predictions/upcoming`, settled fixtures appear in CLV response
- [ ] CLV tab renders in filter bar; toggles correctly
- [ ] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)