### PR TITLE
Add opponent pick tracking to Tipp 11 round summary

### DIFF
--- a/backend/app/routers/picks.py
+++ b/backend/app/routers/picks.py
@@ -27,3 +27,31 @@ async def save_pick(fixture_id: int, body: UserPickRequest):
 @router.delete("/{fixture_id}", status_code=204)
 async def delete_pick(fixture_id: int):
     user_picks.delete_pick(fixture_id)
+
+
+# ---------------------------------------------------------------------------
+# Opponent picks
+# ---------------------------------------------------------------------------
+
+@router.get("/opponent", response_model=list[UserPick])
+async def get_opponent_picks():
+    return user_picks.get_all_opponent_picks()
+
+
+@router.put("/opponent/{fixture_id}", response_model=UserPick)
+async def save_opponent_pick(fixture_id: int, body: UserPickRequest):
+    if body.picked_home < 0 or body.picked_away < 0:
+        raise HTTPException(status_code=422, detail="Goals cannot be negative")
+    return user_picks.save_opponent_pick(
+        fixture_id=fixture_id,
+        matchday=body.matchday,
+        home_team=body.home_team,
+        away_team=body.away_team,
+        picked_home=body.picked_home,
+        picked_away=body.picked_away,
+    )
+
+
+@router.delete("/opponent/{fixture_id}", status_code=204)
+async def delete_opponent_pick(fixture_id: int):
+    user_picks.delete_opponent_pick(fixture_id)

--- a/backend/app/services/user_picks.py
+++ b/backend/app/services/user_picks.py
@@ -36,6 +36,17 @@ def init(db_path: str | Path) -> None:
                 saved_at     TEXT    NOT NULL
             )
         """)
+        con.execute("""
+            CREATE TABLE IF NOT EXISTS opponent_picks (
+                fixture_id   INTEGER PRIMARY KEY,
+                matchday     INTEGER NOT NULL,
+                home_team    TEXT    NOT NULL,
+                away_team    TEXT    NOT NULL,
+                picked_home  INTEGER NOT NULL,
+                picked_away  INTEGER NOT NULL,
+                saved_at     TEXT    NOT NULL
+            )
+        """)
     logger.info("User picks DB ready at %s", _db_path)
 
 
@@ -71,6 +82,50 @@ def get_all_picks() -> list[UserPick]:
         rows = con.execute(
             "SELECT fixture_id, matchday, home_team, away_team, picked_home, picked_away, saved_at "
             "FROM user_picks ORDER BY matchday, fixture_id"
+        ).fetchall()
+    return [
+        UserPick(fixture_id=r[0], matchday=r[1], home_team=r[2], away_team=r[3],
+                 picked_home=r[4], picked_away=r[5], saved_at=r[6])
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Opponent picks (same schema, separate table)
+# ---------------------------------------------------------------------------
+
+def save_opponent_pick(fixture_id: int, matchday: int, home_team: str, away_team: str,
+                       picked_home: int, picked_away: int) -> UserPick:
+    ts = datetime.now(timezone.utc).isoformat()
+    with _conn() as con:
+        con.execute("""
+            INSERT INTO opponent_picks
+                (fixture_id, matchday, home_team, away_team, picked_home, picked_away, saved_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(fixture_id) DO UPDATE SET
+                matchday=excluded.matchday,
+                home_team=excluded.home_team,
+                away_team=excluded.away_team,
+                picked_home=excluded.picked_home,
+                picked_away=excluded.picked_away,
+                saved_at=excluded.saved_at
+        """, (fixture_id, matchday, home_team, away_team, picked_home, picked_away, ts))
+    return UserPick(fixture_id=fixture_id, matchday=matchday, home_team=home_team,
+                    away_team=away_team, picked_home=picked_home, picked_away=picked_away,
+                    saved_at=ts)
+
+
+def delete_opponent_pick(fixture_id: int) -> bool:
+    with _conn() as con:
+        cur = con.execute("DELETE FROM opponent_picks WHERE fixture_id = ?", (fixture_id,))
+    return cur.rowcount > 0
+
+
+def get_all_opponent_picks() -> list[UserPick]:
+    with _conn() as con:
+        rows = con.execute(
+            "SELECT fixture_id, matchday, home_team, away_team, picked_home, picked_away, saved_at "
+            "FROM opponent_picks ORDER BY matchday, fixture_id"
         ).fetchall()
     return [
         UserPick(fixture_id=r[0], matchday=r[1], home_team=r[2], away_team=r[3],

--- a/frontend/src/components/Tipp11Summary.css
+++ b/frontend/src/components/Tipp11Summary.css
@@ -75,6 +75,9 @@
 /* Your pick column */
 .t11s-my-pick-hdr { color: var(--yellow); }
 
+/* Opponent pick column */
+.t11s-opp-pick-hdr { color: var(--red); }
+
 .t11s-my-pick-cell { white-space: nowrap; }
 
 .pick-input-group {
@@ -102,6 +105,10 @@
 .pick-input:focus {
   outline: none;
   border-color: var(--yellow);
+}
+
+.pick-input--opp:focus {
+  border-color: var(--red);
 }
 
 .pick-sep {

--- a/frontend/src/components/Tipp11Summary.jsx
+++ b/frontend/src/components/Tipp11Summary.jsx
@@ -11,7 +11,7 @@ function getBestTip(prediction, useBlend) {
   return bestTipp11Tip(grid)
 }
 
-function PickInput({ fixtureId, matchday, homeTeam, awayTeam, initialPick, onSave }) {
+function PickInput({ fixtureId, matchday, homeTeam, awayTeam, initialPick, onSave, variant }) {
   const [h, setH] = useState(initialPick?.picked_home ?? '')
   const [a, setA] = useState(initialPick?.picked_away ?? '')
   const saveTimer = useRef(null)
@@ -29,10 +29,12 @@ function PickInput({ fixtureId, matchday, homeTeam, awayTeam, initialPick, onSav
     }, 400)
   }
 
+  const cls = `pick-input${variant ? ` pick-input--${variant}` : ''}`
+
   return (
     <span className="pick-input-group">
       <input
-        className="pick-input"
+        className={cls}
         type="number" min="0" max="20"
         value={h}
         onChange={e => { setH(e.target.value); tryCommit(e.target.value, a) }}
@@ -40,7 +42,7 @@ function PickInput({ fixtureId, matchday, homeTeam, awayTeam, initialPick, onSav
       />
       <span className="pick-sep">:</span>
       <input
-        className="pick-input"
+        className={cls}
         type="number" min="0" max="20"
         value={a}
         onChange={e => { setA(e.target.value); tryCommit(h, e.target.value) }}
@@ -51,7 +53,8 @@ function PickInput({ fixtureId, matchday, homeTeam, awayTeam, initialPick, onSav
 }
 
 export default function Tipp11Summary({ predictions, bayesPredictions, useBlend }) {
-  const [picks, setPicks] = useState({}) // keyed by fixture_id
+  const [picks, setPicks] = useState({})           // keyed by fixture_id
+  const [oppPicks, setOppPicks] = useState({})     // keyed by fixture_id
 
   useEffect(() => {
     fetch('/api/picks')
@@ -62,11 +65,18 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
         setPicks(map)
       })
       .catch(() => {})
+    fetch('/api/picks/opponent')
+      .then(r => r.json())
+      .then(data => {
+        const map = {}
+        for (const p of data) map[p.fixture_id] = p
+        setOppPicks(map)
+      })
+      .catch(() => {})
   }, [])
 
   async function handleSave(fixtureId, matchday, homeTeam, awayTeam, pickedHome, pickedAway) {
     if (pickedHome === null) {
-      // delete
       await fetch(`/api/picks/${fixtureId}`, { method: 'DELETE' }).catch(() => {})
       setPicks(prev => { const next = { ...prev }; delete next[fixtureId]; return next })
     } else {
@@ -78,6 +88,23 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
       if (res?.ok) {
         const saved = await res.json()
         setPicks(prev => ({ ...prev, [fixtureId]: saved }))
+      }
+    }
+  }
+
+  async function handleOppSave(fixtureId, matchday, homeTeam, awayTeam, pickedHome, pickedAway) {
+    if (pickedHome === null) {
+      await fetch(`/api/picks/opponent/${fixtureId}`, { method: 'DELETE' }).catch(() => {})
+      setOppPicks(prev => { const next = { ...prev }; delete next[fixtureId]; return next })
+    } else {
+      const res = await fetch(`/api/picks/opponent/${fixtureId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ matchday, home_team: homeTeam, away_team: awayTeam, picked_home: pickedHome, picked_away: pickedAway }),
+      }).catch(() => null)
+      if (res?.ok) {
+        const saved = await res.json()
+        setOppPicks(prev => ({ ...prev, [fixtureId]: saved }))
       }
     }
   }
@@ -103,7 +130,10 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
     const pick    = picks[fixture.id] ?? null
     const myPts   = (isFinished && pick) ? computePoints(pick.picked_home, pick.picked_away, home_score, away_score) : null
 
-    return { fixture, home_team, away_team, matchday, base, bayes, basePts, bayesPts, isFinished, home_score, away_score, pick, myPts }
+    const oppPick = oppPicks[fixture.id] ?? null
+    const oppPts  = (isFinished && oppPick) ? computePoints(oppPick.picked_home, oppPick.picked_away, home_score, away_score) : null
+
+    return { fixture, home_team, away_team, matchday, base, bayes, basePts, bayesPts, isFinished, home_score, away_score, pick, myPts, oppPick, oppPts }
   })
 
   const totalBaseExp  = rows.reduce((s, r) => s + r.base.pts, 0)
@@ -113,6 +143,9 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
   const totalBayesAct = (finishedRows.length > 0 && hasBayes) ? finishedRows.reduce((s, r) => s + (r.bayesPts ?? 0), 0) : null
   const pickedFinished = finishedRows.filter(r => r.myPts !== null)
   const totalMyAct    = pickedFinished.length > 0 ? pickedFinished.reduce((s, r) => s + r.myPts, 0) : null
+
+  const oppPickedFinished = finishedRows.filter(r => r.oppPts !== null)
+  const totalOppAct       = oppPickedFinished.length > 0 ? oppPickedFinished.reduce((s, r) => s + r.oppPts, 0) : null
 
   const showActual = finishedRows.length > 0
   const showResult = showActual
@@ -136,6 +169,8 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
             {showActual && hasBayes && <th>Bayes pts</th>}
             <th className="t11s-my-pick-hdr">Your pick</th>
             {showActual && <th>Your pts</th>}
+            <th className="t11s-opp-pick-hdr">Opp pick</th>
+            {showActual && <th>Opp pts</th>}
           </tr>
         </thead>
         <tbody>
@@ -171,6 +206,23 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
                   {r.myPts !== null ? r.myPts : '–'}
                 </td>
               )}
+              <td className="t11s-my-pick-cell">
+                <PickInput
+                  key={r.oppPick?.saved_at ?? 'opp-empty'}
+                  fixtureId={r.fixture.id}
+                  matchday={r.matchday}
+                  homeTeam={r.home_team.name}
+                  awayTeam={r.away_team.name}
+                  initialPick={r.oppPick}
+                  onSave={handleOppSave}
+                  variant="opp"
+                />
+              </td>
+              {showActual && (
+                <td className={r.oppPts !== null ? `pts-${scoreClass(r.oppPts)}` : 't11s-dash'}>
+                  {r.oppPts !== null ? r.oppPts : '–'}
+                </td>
+              )}
             </tr>
           ))}
         </tbody>
@@ -185,6 +237,8 @@ export default function Tipp11Summary({ predictions, bayesPredictions, useBlend 
             {showActual && hasBayes && <td className={totalBayesAct !== null ? `pts-${scoreClass(totalBayesAct)}` : ''}>{totalBayesAct ?? '–'}</td>}
             <td />
             {showActual && <td className={totalMyAct !== null ? `pts-${scoreClass(totalMyAct)}` : ''}>{totalMyAct ?? '–'}</td>}
+            <td />
+            {showActual && <td className={totalOppAct !== null ? `pts-${scoreClass(totalOppAct)}` : ''}>{totalOppAct ?? '–'}</td>}
           </tr>
         </tfoot>
       </table>


### PR DESCRIPTION
## Summary

- Adds an **Opp pick** column to the Tipp 11 round summary table, mirroring the existing Your pick column
- Opponent picks are persisted to a separate `opponent_picks` SQLite table (created alongside `user_picks` in `init()`)
- New API routes: `GET/PUT/DELETE /api/picks/opponent/{fixture_id}`
- Red column header and red focus ring distinguish opponent inputs from the yellow user inputs
- **Opp pts** column scores the opponent's picks with the same green/yellow/red colouring; total row updated

## Test plan

- [ ] Enter opponent picks for a fixture — confirm they persist across server restart
- [ ] Clear an opponent pick (delete both fields) — confirm it is removed
- [ ] Verify your own picks are unaffected
- [ ] Check Opp pts scoring appears correctly for finished fixtures
- [ ] Confirm total row reflects both your pts and opp pts independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)